### PR TITLE
don't link Math

### DIFF
--- a/src/migrations-truffle-4/3_deploy_GNO.js
+++ b/src/migrations-truffle-4/3_deploy_GNO.js
@@ -8,31 +8,13 @@ function migrate ({
   initialTokenAmount = INITIAL_TOKEN_AMOUNT
 }) {
   const TokenGNO = artifacts.require('TokenGNO')
-  const { Math } = _getDependencies(artifacts, network, deployer)
 
   return deployer
-    .then(() => Math.deployed())
-    .then(() => deployer.link(Math, TokenGNO))
     .then(() => {
       const owner = accounts[0]
       console.log('Deploying GNO with owner: %s', owner)
       return deployer.deploy(TokenGNO, initialTokenAmount * 1e18)
     })
-}
-
-function _getDependencies (artifacts, network, deployer) {
-  let Math
-  if (network === 'development') {
-    Math = artifacts.require('GnosisMath')
-  } else {
-    const contract = require('truffle-contract')
-    Math = contract(require('@gnosis.pm/util-contracts/build/contracts/Math'))
-    Math.setProvider(deployer.provider)
-  }
-
-  return {
-    Math
-  }
 }
 
 module.exports = migrate

--- a/src/migrations-truffle-5/3_deploy_GNO.js
+++ b/src/migrations-truffle-5/3_deploy_GNO.js
@@ -10,11 +10,6 @@ async function migrate ({
 }) {
   const BN = web3.utils.BN
   const TokenGNO = artifacts.require('TokenGNO')
-  const { Math } = _getDependencies(artifacts, network, deployer)
-
-  console.log('Link Math lib to TokenGNO')
-  await Math.deployed()
-  deployer.link(Math, TokenGNO)
 
   const owner = accounts[0]
   console.log('Deploy TokenGNO:')
@@ -25,21 +20,6 @@ async function migrate ({
     'ether'
   )
   return deployer.deploy(TokenGNO, initialTokenAmountWei)
-}
-
-function _getDependencies (artifacts, network, deployer) {
-  let Math
-  if (network === 'development') {
-    Math = artifacts.require('GnosisMath')
-  } else {
-    const contract = require('truffle-contract')
-    Math = contract(require('@gnosis.pm/util-contracts/build/contracts/Math'))
-    Math.setProvider(deployer.provider)
-  }
-
-  return {
-    Math
-  }
 }
 
 module.exports = migrate


### PR DESCRIPTION
Since solidity inlines internal library functions inside the contract code, there's no need to deploy and link Math library anymore.